### PR TITLE
Infer issue ID from tempo log entry description, when possible

### DIFF
--- a/src/Tempo/Domain/JiraIssueId.php
+++ b/src/Tempo/Domain/JiraIssueId.php
@@ -27,6 +27,7 @@ final class JiraIssueId
         );
     }
 
+    /** @throws InvariantViolationException */
     public static function fromSelfUrl(string $url): self
     {
         $match = Psl\Regex\first_match(
@@ -38,6 +39,34 @@ final class JiraIssueId
         );
 
         Psl\invariant($match !== null, 'Url "' . $url . '" does not contain a Jira issue ID');
+
+        return new self($match[1]);
+    }
+
+    /**
+     * Guesses the Jira issue ID by looking at a URL.
+     * If the URL doesn't match, we look at the description, searching for
+     * anything that may resemble a Jira issue identifier, picking that as
+     * our best guess.
+     */
+    public static function fromSelfUrlOrDescription(string $url, string $description): self|null
+    {
+        try {
+            return self::fromSelfUrl($url);
+        } catch (InvariantViolationException) {
+        }
+
+        $match = Psl\Regex\first_match(
+            $description,
+            '/([A-Z][A-Z0-9]*-[0-9]+)/',
+            Psl\Type\shape([
+                1 => Psl\Type\non_empty_string(),
+            ]),
+        );
+
+        if ($match === null) {
+            return null;
+        }
 
         return new self($match[1]);
     }

--- a/test/Tempo/Domain/JiraIssueIdTest.php
+++ b/test/Tempo/Domain/JiraIssueIdTest.php
@@ -72,6 +72,22 @@ final class JiraIssueIdTest extends TestCase
         self::assertSame($id, JiraIssueId::fromSelfUrl($url)->id);
     }
 
+    /**
+     * @param non-empty-string $expectedId
+     *
+     * @dataProvider validSelfUrlsAndDescriptions
+     */
+    public function testFromValidSelfUrlOrDescription(
+        string $url,
+        string $description,
+        string $expectedId,
+    ): void {
+        $id = JiraIssueId::fromSelfUrlOrDescription($url, $description);
+
+        self::assertNotNull($id);
+        self::assertSame($expectedId, $id->id);
+    }
+
     /** @return non-empty-list<array{non-empty-string, non-empty-string}> */
     public function validSelfUrls(): array
     {
@@ -79,6 +95,17 @@ final class JiraIssueIdTest extends TestCase
             ['/A-1', 'A-1'],
             ['http://example.com/A-2', 'A-2'],
             ['https://foo.atlassian.net/rest/api/2/issue/AB-123', 'AB-123'],
+        ];
+    }
+
+    /** @return non-empty-list<array{string, string, non-empty-string}> */
+    public function validSelfUrlsAndDescriptions(): array
+    {
+        return [
+            ['/A-1', 'A-1', 'A-1'],
+            ['/', 'A-1', 'A-1'],
+            ['/', 'I worked on A-1 during the night', 'A-1'],
+            ['/', 'i worked on AA-11 during the night', 'AA-11'],
         ];
     }
 
@@ -122,6 +149,49 @@ final class JiraIssueIdTest extends TestCase
             [
                 'https://foo.atlassian.net/rest/api/2/issue/123',
                 'Url "https://foo.atlassian.net/rest/api/2/issue/123" does not contain a Jira issue ID',
+            ],
+        ];
+    }
+
+    /**
+     * @param non-empty-string $expectedExceptionMessage
+     *
+     * @dataProvider invalidSelfUrlsAndDescriptions
+     */
+    public function testFromInvalidSelfUrlOrDescription(
+        string $url,
+        string $description,
+    ): void {
+        self::assertNull(JiraIssueId::fromSelfUrlOrDescription($url, $description));
+    }
+
+    /** @return non-empty-list<array{string, string}> */
+    public function invalidSelfUrlsAndDescriptions(): array
+    {
+        return [
+            [
+                '',
+                '',
+            ],
+            [
+                '/A-',
+                'FOO-',
+            ],
+            [
+                'http://example.com/FOO',
+                ' FOO - BAR',
+            ],
+            [
+                'http://example.com/FOO',
+                ' FOO - 123',
+            ],
+            [
+                'http://example.com/FOO',
+                ' FOO- 123',
+            ],
+            [
+                'http://example.com/FOO',
+                ' FOO -123',
             ],
         ];
     }


### PR DESCRIPTION
Sometimes, Tempo does not give us issue URLs like
`https://foo.atlassian.net/rest/api/2/issue/AB-12`, but instead gives us the middle finger, telling us "your problem now", with a URL like: `https://foo.atlassian.net/rest/api/2/issue/12345`.

This would require an `O(n)` lookup in the Jira API (new API client required), and I can't currently configure such an integration, because all my attempts to create a working Jira API token, as well as talking to the API with it, have failed.

Because of that, we introduce some more aggressive resiliency when we scan for existing log entry in the Tempo log entries, by:

 1. searching for the issue ID in the URL
 2. if that fails, search for an issue ID in the log entry description

Since we generate log entries with the issue ID prepended/appended/etc, this is relatively usable: an ugly solution to the daily ugliness of Jira and its obnoxious ecosystem.