### PR TITLE
Switch back to Tempo's V3 API, since V4 is full of unexpected BC breaks

### DIFF
--- a/bin/sync-everything.php
+++ b/bin/sync-everything.php
@@ -12,8 +12,8 @@ use Psl;
 use TimeSync\Harvest\Infrastructure\GetTimeEntriesFromV2Api;
 use TimeSync\SyncHarvestToTempo\Domain\SendHarvestEntryToTempo;
 use TimeSync\Tempo\Domain\JiraIssueId;
-use TimeSync\Tempo\Infrastructure\AddWorkLogEntryViaTempoV4Api;
-use TimeSync\Tempo\Infrastructure\GetWorkLogEntriesViaTempoV4Api;
+use TimeSync\Tempo\Infrastructure\AddWorkLogEntryViaTempoV3Api;
+use TimeSync\Tempo\Infrastructure\GetWorkLogEntriesViaTempoV3Api;
 
 (static function (): void {
     require_once __DIR__ . '/../vendor/autoload.php';
@@ -33,13 +33,13 @@ use TimeSync\Tempo\Infrastructure\GetWorkLogEntriesViaTempoV4Api;
 
     $syncEntry = new SendHarvestEntryToTempo(
         $fallbackJiraIssue,
-        new GetWorkLogEntriesViaTempoV4Api(
+        new GetWorkLogEntriesViaTempoV3Api(
             $httpClient,
             $requestFactory,
             $secrets['TEMPO_ACCESS_TOKEN'],
             $fallbackJiraIssue,
         ),
-        new AddWorkLogEntryViaTempoV4Api(
+        new AddWorkLogEntryViaTempoV3Api(
             $httpClient,
             $requestFactory,
             $secrets['TEMPO_ACCESS_TOKEN'],

--- a/src/Tempo/Infrastructure/AddWorkLogEntryViaTempoV3Api.php
+++ b/src/Tempo/Infrastructure/AddWorkLogEntryViaTempoV3Api.php
@@ -10,7 +10,8 @@ use Psr\Http\Message\RequestFactoryInterface;
 use TimeSync\Tempo\Domain\LogEntry;
 use TimeSync\Tempo\Domain\SetWorkLogEntry;
 
-final class AddWorkLogEntryViaTempoV4Api implements SetWorkLogEntry
+/** @link https://apidocs.tempo.io/#worklogs */
+final class AddWorkLogEntryViaTempoV3Api implements SetWorkLogEntry
 {
     /**
      * @param non-empty-string $tempoBearerToken
@@ -27,7 +28,7 @@ final class AddWorkLogEntryViaTempoV4Api implements SetWorkLogEntry
     public function __invoke(LogEntry $logEntry): void
     {
         $request = $this->makeRequest
-            ->createRequest('POST', 'https://api.tempo.io/4/worklogs')
+            ->createRequest('POST', 'https://api.tempo.io/core/3/worklogs')
             ->withHeader('Authorization', 'Bearer ' . $this->tempoBearerToken)
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('Accept', 'application/json');
@@ -48,7 +49,8 @@ final class AddWorkLogEntryViaTempoV4Api implements SetWorkLogEntry
             $response->getStatusCode() === 200,
             'Request '
             . $request->getMethod() . ' ' . $request->getUri()->__toString()
-            . '  not successful: ' . $response->getStatusCode(),
+            . '  not successful: ' . $response->getStatusCode()
+            . "\n" . $response->getBody()->__toString(),
         );
     }
 }

--- a/src/Tempo/Infrastructure/GetWorkLogEntriesViaTempoV3Api.php
+++ b/src/Tempo/Infrastructure/GetWorkLogEntriesViaTempoV3Api.php
@@ -19,7 +19,7 @@ use function array_values;
 use function implode;
 
 /** @link https://apidocs.tempo.io/v4/#section/API-conventions */
-final class GetWorkLogEntriesViaTempoV4Api implements GetWorkLogEntries
+final class GetWorkLogEntriesViaTempoV3Api implements GetWorkLogEntries
 {
     /**
      * @param non-empty-string $harvestAccountId
@@ -52,7 +52,7 @@ final class GetWorkLogEntriesViaTempoV4Api implements GetWorkLogEntries
             . '&limit=1000';
 
         $request = $this->makeRequest
-            ->createRequest('GET', 'https://api.tempo.io/4/worklogs');
+            ->createRequest('GET', 'https://api.tempo.io/core/3/worklogs');
 
         $request = $request
             ->withUri(
@@ -66,7 +66,9 @@ final class GetWorkLogEntriesViaTempoV4Api implements GetWorkLogEntries
 
         Psl\invariant(
             $response->getStatusCode() === 200,
-            'Request ' . $request->getUri()->__toString() . '  not successful: ' . $response->getStatusCode(),
+            'Request ' . $request->getUri()->__toString()
+            . '  not successful: ' . $response->getStatusCode()
+            . "\n" . $response->getBody()->__toString(),
         );
 
         $logEntries = array_filter(array_map(


### PR DESCRIPTION
Overnight, the API at https://apidocs.tempo.io/v4/#tag/Worklogs/operation/createWorklog, stopped accepting `issueKey`, and now requires providing an `issueId`, which is an `int64` to be retrieved from the Jira API.

This happened between these two runs:

 * OK @ 2022-10-17: https://github.com/Ocramius/harvest-to-jira-tempo-time-sync/actions/runs/3263948869
 * KO @ 2022-10-25: https://github.com/Ocramius/harvest-to-jira-tempo-time-sync/actions/runs/3316607044

The Jira API is pretty bad on its own, and we don't want to have anything to do with it **ON TOP** of the TempoHQ API.

In order to preserve our own sanity: fuck that, we go back to the Tempo V3 API, which seems stable, or abandoned, whatever, the important thing is that it doesn't change under my nose.

Ref: https://apidocs.tempo.io/#worklogs
Ref: https://apidocs.tempo.io/v4/#tag/Worklogs/operation/createWorklog
Ref: https://twitter.com/Ocramius/status/1584716529773735942