### PR TITLE
Only sync time-tracking entries that weren't invoiced yet

### DIFF
--- a/src/Harvest/Infrastructure/GetTimeEntriesFromV2Api.php
+++ b/src/Harvest/Infrastructure/GetTimeEntriesFromV2Api.php
@@ -92,7 +92,10 @@ final class GetTimeEntriesFromV2Api implements GetTimeEntries
                 'GET',
                 $uri
                 ?? $this->uriFactory->createUri('https://api.harvestapp.com/v2/time_entries')
-                ->withQuery(http_build_query(['project_id' => $projectId])),
+                ->withQuery(http_build_query([
+                    'project_id' => $projectId,
+                    'is_billed'  => 'false',
+                ])),
             )
             ->withAddedHeader('Harvest-Account-Id', $this->harvestAccountId)
             ->withAddedHeader('Authorization', 'Bearer ' . $this->harvestBearerToken)

--- a/test/Harvest/Infrastructure/GetTimeEntriesFromV2ApiTest.php
+++ b/test/Harvest/Infrastructure/GetTimeEntriesFromV2ApiTest.php
@@ -70,7 +70,7 @@ JSON,
             ->method('sendRequest')
             ->with(self::callback(static function (RequestInterface $request): bool {
                 self::assertSame(
-                    'https://api.harvestapp.com/v2/time_entries?project_id=def456',
+                    'https://api.harvestapp.com/v2/time_entries?project_id=def456&is_billed=false',
                     $request
                         ->getUri()
                         ->__toString(),
@@ -104,7 +104,7 @@ JSON,
             ->willReturn($response);
 
         $this->expectException(InvariantViolationException::class);
-        $this->expectExceptionMessage('Request https://api.harvestapp.com/v2/time_entries?project_id=def456  not successful: 201');
+        $this->expectExceptionMessage('Request https://api.harvestapp.com/v2/time_entries?project_id=def456&is_billed=false  not successful: 201');
 
         ($this->getTimeEntries)('def456');
     }


### PR DESCRIPTION
Fixes #57

This reduces the sync scope by a ton, therefore reducing scope of data validity, and therefore improving stability.